### PR TITLE
Address and Household Bug Fixes

### DIFF
--- a/getyour/app/templates/application/address.html
+++ b/getyour/app/templates/application/address.html
@@ -38,7 +38,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 {% if not update_mode %}
 <h2 style="font-weight: 700; margin:5vh 0"> Where do you live?</h2>
-<h5 class="address-header" style="font-weight: 700"> Home Address</h5>
 {% endif %}
 
 <form action="{% url 'app:address' %}" method="post" autocomplete="false" enctype="multipart/form-data">
@@ -97,7 +96,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
     <div id="mailing_address_wrapper">
         <h2 style="font-weight: 700; margin:5vh 0"> What's your mailing address?</h2>
-        <h5 class="address-header" style="font-weight: 700;"> Mailing Address</h5>
         {% for field in mailing_address_form %}
         {% if field.label == "State" %}
         <div class="row" style="width:100%">

--- a/getyour/app/templates/application/address.html
+++ b/getyour/app/templates/application/address.html
@@ -37,7 +37,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {% endwith %}
 
 {% if not update_mode %}
-<h2 style="font-weight: 700; margin:5vh 0"> Where do you live? </h2>
+<h2 style="font-weight: 700; margin:5vh 0"> Where do you live?</h2>
+<h5 class="address-header" style="font-weight: 700"> Home Address</h5>
 {% endif %}
 
 <form action="{% url 'app:address' %}" method="post" autocomplete="false" enctype="multipart/form-data">
@@ -95,7 +96,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     {% endif %}
 
     <div id="mailing_address_wrapper">
-        <h2 style="font-weight: 700; margin:5vh 0"> What's your mailing address? </h2>
+        <h2 style="font-weight: 700; margin:5vh 0"> What's your mailing address?</h2>
+        <h5 class="address-header" style="font-weight: 700;"> Mailing Address</h5>
         {% for field in mailing_address_form %}
         {% if field.label == "State" %}
         <div class="row" style="width:100%">
@@ -137,6 +139,24 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
         {% endif %}
     </div>
 </form>
+
+<style>
+    @media screen and (max-width : 767px) {
+        .address-header {
+            color: white;
+            margin-top: 0px;
+            margin-bottom: 10px;
+        }
+    }
+
+    @media screen and (min-width: 768px) {
+        .address-header {
+            color: var(--darkblue);
+            margin-top: 0px;
+            margin-bottom: 10px;
+        }
+    }
+</style>
 
 <script>
     $(document).ready(function () {

--- a/getyour/app/templates/application/address.html
+++ b/getyour/app/templates/application/address.html
@@ -57,15 +57,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
         <div class="input" style="width:100%">
             <!--TODO: Save input-->
             <input class="fill" value="{{ field.value|default:'' }}" name="{{ field.name }}" id="state"
-                maxlength="{{ field.max_length }}" type="text" style="width:80%;" required autocomplete="off">
+                maxlength="{{ field.max_length }}" type="text" style="width:80%;" autocomplete="off" required>
             <label class="label">{{field.label}}</label>
         </div>
         <div class="input" style="width:100%">
             <!--TODO: change this to dropdown menu with data-->
             <input class="fill" value="{{ eligibility_address_form.zip_code.value|default:'' }}"
-                name="{{ eligibility_address_form.zip_code.name }}" id="zip_code"
-                maxlength="{{ eligibility_address_form.zip_code.max_length }}" type="number" style="width:100%;"
-                required autocomplete="off">
+                name="{{ eligibility_address_form.zip_code.name }}" id="zip_code" pattern="[0-9]{5}"
+                title="Please enter a 5-digit Zip Code" maxlength="5" type="text" style="width:100%;" autocomplete="off"
+                required>
             <label class="label">{{ eligibility_address_form.zip_code.label }}</label>
         </div>
     </div>
@@ -102,16 +102,16 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
             <div class="input" style="width:100%">
                 <!--TODO: Save input-->
                 <input class="fill" value="{{ field.value|default:'' }}" name="mailing_{{ field.name }}"
-                    id="mailing_state" maxlength="{{ field.max_length }}" type="text" style="width:80%;" required
-                    autocomplete="off">
+                    id="mailing_state" maxlength="{{ field.max_length }}" type="text" style="width:80%;"
+                    autocomplete="off" required>
                 <label class="label">{{field.label}}</label>
             </div>
             <div class="input" style="width:100%">
                 <!--TODO: change this to dropdown menu with data-->
                 <input class="fill" value="{{ mailing_address_form.zip_code.value|default:'' }}"
-                    name="mailing_{{ mailing_address_form.zip_code.name }}" id="mailing_zip_code"
-                    maxlength="{{ mailing_address_form.zip_code.max_length }}" type="number" style="width:100%;"
-                    required autocomplete="off">
+                    name="mailing_{{ mailing_address_form.zip_code.name }}" id="mailing_zip_code" pattern="[0-9]{5}"
+                    title="Please enter a 5-digit Zip Code" maxlength="5" type="text" style="width:100%;"
+                    autocomplete="off" required>
                 <label class="label">{{ mailing_address_form.zip_code.label }}</label>
             </div>
         </div>
@@ -139,16 +139,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 </form>
 
 <script>
-
     $(document).ready(function () {
-        $("#mailing_zip_code, #zip_code").blur(function () {
-            zipCheck(this);
-        });
-
-        $("#mailing_state, #state").blur(function () {
-            stateNameToAbbreviation(this);
-        });
-
         {% if not update_mode %}
         var sameAddress = "{{ same_address }}" === "True";
         var mailingAddressHtml = $("#mailing_address_wrapper").html();
@@ -182,136 +173,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
         }
     }
     {% endif %}
-
-    function stateNameToAbbreviation(stateName) {
-        var states = {
-            "arizona": "AZ",
-            "alabama": "AL",
-            "alaska": "AK",
-            "arkansas": "AR",
-            "california": "CA",
-            "colorado": "CO",
-            "connecticut": "CT",
-            "district of columbia": "DC",
-            "delaware": "DE",
-            "florida": "FL",
-            "georgia": "GA",
-            "hawaii": "HI",
-            "idaho": "ID",
-            "illinois": "IL",
-            "indiana": "IN",
-            "iowa": "IA",
-            "kansas": "KS",
-            "kentucky": "KY",
-            "louisiana": "LA",
-            "maine": "ME",
-            "maryland": "MD",
-            "massachusetts": "MA",
-            "michigan": "MI",
-            "minnesota": "MN",
-            "mississippi": "MS",
-            "missouri": "MO",
-            "montana": "MT",
-            "nebraska": "NE",
-            "nevada": "NV",
-            "new hampshire": "NH",
-            "new jersey": "NJ",
-            "new mexico": "NM",
-            "new york": "NY",
-            "north carolina": "NC",
-            "north dakota": "ND",
-            "ohio": "OH",
-            "oklahoma": "OK",
-            "oregon": "OR",
-            "pennsylvania": "PA",
-            "rhode island": "RI",
-            "south carolina": "SC",
-            "south dakota": "SD",
-            "tennessee": "TN",
-            "texas": "TX",
-            "utah": "UT",
-            "vermont": "VT",
-            "virginia": "VA",
-            "washington": "WA",
-            "west virginia": "WV",
-            "wisconsin": "WI",
-            "wyoming": "WY",
-            "american samoa": "AS",
-            "guam": "GU",
-            "northern mariana islands": "MP",
-            "puerto rico": "PR",
-            "us virgin islands": "VI",
-            "us minor outlying islands": "UM",
-
-            "az": "AZ",
-            "al": "AL",
-            "ak": "AK",
-            "ar": "AR",
-            "ca": "CA",
-            "co": "CO",
-            "ct": "CT",
-            "dc": "DC",
-            "de": "DE",
-            "fl": "FL",
-            "ga": "GA",
-            "hi": "HI",
-            "id": "ID",
-            "il": "IL",
-            "in": "IN",
-            "ia": "IA",
-            "ks": "KS",
-            "ky": "KY",
-            "la": "LA",
-            "me": "ME",
-            "md": "MD",
-            "ma": "MA",
-            "mi": "MI",
-            "mn": "MN",
-            "ms": "MS",
-            "mo": "MO",
-            "mt": "MT",
-            "ne": "NE",
-            "nv": "NV",
-            "nh": "NH",
-            "nj": "NJ",
-            "nm": "NM",
-            "ny": "NY",
-            "nc": "NC",
-            "nd ": "ND",
-            "oh": "OH",
-            "ok": "OK",
-            "or": "OR",
-            "pa": "PA",
-            "ri ": "RI",
-            "sc ": "SC",
-            "sd ": "SD",
-            "tn": "TN",
-            "tx": "TX",
-            "ut": "UT",
-            "vt": "VT",
-            "va": "VA",
-            "wa": "WA",
-            "wv ": "WV",
-            "wi": "WI",
-            "wy": "WY",
-            "as": "AS",
-            "gu": "GU",
-            "mp  ": "MP",
-            "pr ": "PR",
-            "vi": "VI",
-            "um": "UM"
-        }
-
-        stateName.value = stateName.value.trim().replace(/[^\w ]/g, "").toLowerCase();
-        //Trim, remove all non-word characters with the exception of spaces, and convert to lowercase
-        if (stateName.value != null) {
-            stateName.value = states[stateName.value];
-        }
-        if (stateName.value == "undefined") {
-            stateName.value = "";
-            alert("Please re-enter your state again")
-        }
-    }
 
     function zipCheck(zipCode) {
         if (zipCode.value.length != 5) {

--- a/getyour/app/templates/application/address_correction.html
+++ b/getyour/app/templates/application/address_correction.html
@@ -30,7 +30,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 {% block body %}
 <!--NOTE: For the future have numbers change based on database-->
-<h2 style="margin-bottom: 0;">We found this address for you, please click it to confirm.</h2>
+{% if address_type == "mailing" %}
+<h2 style="margin-bottom: 0;">We found this mailing address for you, please click it to confirm.</h2>
+{% else %}
+<h2 style="margin-bottom: 0;">We found this home address for you, please click it to confirm.</h2>
+{% endif %}
 <br>
 <!-- NOTE GRACE START HERE-->
 <div class="fadeSmall">

--- a/getyour/app/templates/application/household.html
+++ b/getyour/app/templates/application/household.html
@@ -87,10 +87,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
         {% if update_mode %}
         <input class="fill" type="text" name="{{ form.number_persons_in_household.name }}"
             id="{{ form.number_persons_in_household.id_for_label}}" value="{{ form.number_persons_in_household.value }}"
-            style="height: 3vh;" required>
+            style="height: 3vh;" pattern="[1-9]\d*" title="Number of household members must be a positive whole number" required>
         {% else %}
         <input class="fill" type="text" name="{{ form.number_persons_in_household.name }}"
-            id="{{ form.number_persons_in_household.id_for_label}}" style="height: 3vh;" required>
+            id="{{ form.number_persons_in_household.id_for_label}}" style="height: 3vh;" pattern="[1-9]\d*" title="Number of household members must be a positive whole number" required>
         {% endif %}
     </div>
 

--- a/getyour/app/views/application.py
+++ b/getyour/app/views/application.py
@@ -270,9 +270,9 @@ def address_correction(request):
     try:
         addresses = json.loads(request.session['application_addresses'])
         in_progress_address = [
-            address for address in addresses if not address['processed']][0]['address']
-        q = QueryDict(urlencode(in_progress_address), mutable=True)
-        q_orig = QueryDict(urlencode(in_progress_address), mutable=True)
+            address for address in addresses if not address['processed']][0]
+        q = QueryDict(urlencode(in_progress_address['address']), mutable=True)
+        q_orig = QueryDict(urlencode(in_progress_address['address']), mutable=True)
 
         # Loop through maxLoopIdx+1 times to try different methods of
         # parsing the address
@@ -443,8 +443,8 @@ def address_correction(request):
             return redirect(reverse("app:take_usps_address"))
 
     print('Address match not found - proceeding to addressCorrection')
-    program_string = [in_progress_address['address1'], in_progress_address['address2'],
-                      in_progress_address['city'] + " " + in_progress_address['state'] + " " + in_progress_address['zipcode']]
+    program_string = [in_progress_address['address']['address1'], in_progress_address['address']['address2'],
+                      in_progress_address['address']['city'] + " " + in_progress_address['address']['state'] + " " + in_progress_address['address']['zipcode']]
     return render(
         request,
         'application/address_correction.html',
@@ -453,6 +453,7 @@ def address_correction(request):
             'form_page_number': form_page_number,
             'program_string': program_string,
             'program_string_2': program_string_2,
+            'address_type': in_progress_address['type'],
             'title': "Address Correction",
         },
     )

--- a/getyour/app/views/application.py
+++ b/getyour/app/views/application.py
@@ -191,6 +191,22 @@ def address(request):
 
     if request.method == "POST":
         addresses = []
+
+        if not update_mode:
+            eligibility_address = {
+                'address1': request.POST['address1'],
+                'address2': request.POST['address2'],
+                'city': request.POST['city'],
+                'state': request.POST['state'],
+                'zipcode': request.POST['zip_code'],
+            }
+            addresses.append(
+                {
+                    'address': eligibility_address,
+                    'type': 'eligibility',
+                    'processed': False
+                })
+            
         # 'no' means the user has a different mailing address
         # compared to their eligibility address
         if request.POST.get('mailing_address') == 'no' or update_mode:
@@ -205,21 +221,6 @@ def address(request):
                 {
                     'address': mailing_address,
                     'type': 'mailing',
-                    'processed': False
-                })
-
-        if not update_mode:
-            eligibility_address = {
-                'address1': request.POST['address1'],
-                'address2': request.POST['address2'],
-                'city': request.POST['city'],
-                'state': request.POST['state'],
-                'zipcode': request.POST['zip_code'],
-            }
-            addresses.append(
-                {
-                    'address': eligibility_address,
-                    'type': 'eligibility',
                     'processed': False
                 })
 


### PR DESCRIPTION
- Fixed client-side address state and zip code validation. Moved validation from JavaScript to HTML. Removed `stateNameToAbbreviation` function, as USPS address validation handles this for us
- Fixed client-side number of household members validation. Added validation to HTML input.
- Added labels for `Mailing Address` and `House Address` on Address page. Also, reordered the USPS validation, so `eligibility address` could be corrected before `mailing address`