### PR TITLE
Add administration functions

### DIFF
--- a/ref/sql/fn_app_household_setincomeverified.sql
+++ b/ref/sql/fn_app_household_setincomeverified.sql
@@ -1,0 +1,64 @@
+CREATE OR REPLACE FUNCTION public.app_household_setincomeverified(VARIADIC p_id integer[])
+ RETURNS character varying
+ LANGUAGE plpgsql
+AS $$
+declare
+  v_exist_subset integer[] default array[]::integer[];
+  v_no_exist varchar(1000) default '';
+  v_no_update varchar(1000) default '';
+  v_row_count integer DEFAULT 0;
+  v_no_update_count integer DEFAULT 0;
+  out_msg varchar(1000) default '';
+begin
+
+  -- Get users from input that aren't in the target table
+  select array_agg(user_id) into v_exist_subset from public.app_household
+  where user_id = any(p_id);
+ 
+  -- Compare p_id with v_exist_subset and output nonexistent users
+  select array_to_string(array_diff(p_id, v_exist_subset), ', ') into v_no_exist;
+
+  -- Get users from input who are already income-verified
+  select string_agg(user_id::text, ', '), count(user_id) into v_no_update, v_no_update_count from public.app_household
+  where is_income_verified = true
+  and user_id = any(p_id);
+	
+  -- Update app_household table
+  UPDATE public.app_household
+  SET is_income_verified = true
+  WHERE user_id = any(p_id);
+    
+  -- Get number of included rows
+  get diagnostics v_row_count = row_count;
+ 
+  -- Output completion details
+ 
+  -- Determine plural
+  if v_row_count-v_no_update_count != 1 then
+  	out_msg = concat(v_row_count-v_no_update_count, ' users verified.');
+  else
+  	out_msg = concat(v_row_count-v_no_update_count, ' user verified.');
+  end if;
+ 
+  if v_no_update != '' then
+  	-- Determine plural
+    if (select substring(v_no_update from ',')) is not null then
+    	out_msg = concat(out_msg, ' IDs ', v_no_update, ' were already verified.');
+    else
+  		out_msg = concat(out_msg, ' ID ', v_no_update, ' was already verified.');
+    end if;
+  end if;
+  
+  if v_no_exist != '' then
+  	-- Determine plural
+  	if (select substring(v_no_exist from ',')) is not null then
+  		out_msg = concat(out_msg, ' IDs ', v_no_exist, ' don''t exist.');
+  	else
+  		out_msg = concat(out_msg, ' ID ', v_no_exist, ' doesn''t exist.');
+  	end if;
+  end if;
+  
+  return out_msg;
+END
+$$
+;

--- a/ref/sql/fn_app_household_unsetincomeverified.sql
+++ b/ref/sql/fn_app_household_unsetincomeverified.sql
@@ -1,0 +1,64 @@
+CREATE OR REPLACE FUNCTION public.app_household_unsetincomeverified(VARIADIC p_id integer[])
+ RETURNS character varying
+ LANGUAGE plpgsql
+AS $$
+declare
+  v_exist_subset integer[] default array[]::integer[];
+  v_no_exist varchar(1000) default '';
+  v_no_update varchar(1000) default '';
+  v_row_count integer DEFAULT 0;
+  v_no_update_count integer DEFAULT 0;
+  out_msg varchar(1000) default '';
+begin
+
+  -- Get users from input that aren't in the target table
+  select array_agg(user_id) into v_exist_subset from public.app_household
+  where user_id = any(p_id);
+ 
+  -- Compare p_id with v_exist_subset and output nonexistent users
+  select array_to_string(array_diff(p_id, v_exist_subset), ', ') into v_no_exist;
+
+  -- Get users from input who are already not income-verified
+  select string_agg(user_id::text, ', '), count(user_id) into v_no_update, v_no_update_count from public.app_household
+  where is_income_verified = false
+  and user_id = any(p_id);
+	
+  -- Update app_household table
+  UPDATE public.app_household
+  SET is_income_verified = false
+  WHERE user_id = any(p_id);
+    
+  -- Get number of included rows
+  get diagnostics v_row_count = row_count;
+ 
+  -- Output completion details
+ 
+  -- Determine plural
+  if v_row_count-v_no_update_count != 1 then
+  	out_msg = concat(v_row_count-v_no_update_count, ' users unverified.');
+  else
+  	out_msg = concat(v_row_count-v_no_update_count, ' user unverified.');
+  end if;
+ 
+  if v_no_update != '' then
+  	-- Determine plural
+    if (select substring(v_no_update from ',')) is not null then
+    	out_msg = concat(out_msg, ' IDs ', v_no_update, ' were already unverified.');
+    else
+  		out_msg = concat(out_msg, ' ID ', v_no_update, ' was already unverified.');
+    end if;
+  end if;
+  
+  if v_no_exist != '' then
+  	-- Determine plural
+  	if (select substring(v_no_exist from ',')) is not null then
+  		out_msg = concat(out_msg, ' IDs ', v_no_exist, ' don''t exist.');
+  	else
+  		out_msg = concat(out_msg, ' ID ', v_no_exist, ' doesn''t exist.');
+  	end if;
+  end if;
+  
+  return out_msg;
+END
+$$
+;

--- a/ref/sql/fn_app_iqprogram_setenrolled.sql
+++ b/ref/sql/fn_app_iqprogram_setenrolled.sql
@@ -1,0 +1,81 @@
+CREATE OR REPLACE FUNCTION public.app_iqprogram_setenrolled(programname varchar(40), VARIADIC p_id integer[])
+ RETURNS character varying
+ LANGUAGE plpgsql
+AS $$
+declare
+  programid integer default 0;
+  v_exist_subset integer[] default array[]::integer[];
+  v_no_exist varchar(1000) default '';
+  v_no_update varchar(1000) default '';
+  v_row_count integer DEFAULT 0;
+  out_msg varchar(1000) default '';
+begin
+	
+  -- Get the program_id for use in the rest of the script
+  select id into programid from public.app_iqprogramrd 
+  where is_active = true 
+  and program_name = programname;
+ 
+  -- Ensure the program exists
+  if programid is null then
+  	out_msg = 'The specified program is not an active program.';
+  	
+  else
+
+    -- Get users from input that aren't in the target table
+    select array_agg(user_id) into v_exist_subset from public.app_iqprogram
+    where program_id = programid 
+    and user_id = any(p_id);
+   
+    -- Compare p_id with v_exist_subset and output nonexistent users
+    select array_to_string(array_diff(p_id, v_exist_subset), ', ') into v_no_exist;
+  
+    -- Get users from input who are already enrolled
+    select string_agg(user_id::text, ', ') into v_no_update from public.app_iqprogram
+    where program_id = programid 
+    and is_enrolled = true
+    and user_id = any(p_id);
+  	
+    -- Update app_iqprogram table, but only if is_enrolled is false (for timestamp validity)
+    UPDATE public.app_iqprogram
+    SET is_enrolled = true, enrolled_at = now()
+    WHERE program_id = programid 
+    and is_enrolled = false
+    and user_id = any(p_id);
+   
+    -- Get number of included rows
+    get diagnostics v_row_count = row_count;
+   
+    -- Output completion details
+   
+    -- Determine plural
+    if v_row_count != 1 then
+    	out_msg = concat(v_row_count, ' users enrolled.');
+    else
+    	out_msg = concat(v_row_count, ' user enrolled.');
+    end if;
+   
+    if v_no_update != '' then
+    	-- Determine plural
+      if (select substring(v_no_update from ',')) is not null then
+      	out_msg = concat(out_msg, ' IDs ', v_no_update, ' were already enrolled.');
+      else
+    		out_msg = concat(out_msg, ' ID ', v_no_update, ' was already enrolled.');
+      end if;
+    end if;
+    
+    if v_no_exist != '' then
+    	-- Determine plural
+    	if (select substring(v_no_exist from ',')) is not null then
+    		out_msg = concat(out_msg, ' IDs ', v_no_exist, ' don''t exist for this program.');
+    	else
+    		out_msg = concat(out_msg, ' ID ', v_no_exist, ' doesn''t exist for this program.');
+    	end if;
+    end if;
+   
+  end if;
+  
+  return out_msg;
+END
+$$
+;

--- a/ref/sql/fn_app_iqprogram_unsetenrolled_REF_ONLY.sql
+++ b/ref/sql/fn_app_iqprogram_unsetenrolled_REF_ONLY.sql
@@ -1,0 +1,81 @@
+CREATE OR REPLACE FUNCTION public.app_iqprogram_unsetenrolled(programname varchar(40), VARIADIC p_id integer[])
+ RETURNS character varying
+ LANGUAGE plpgsql
+AS $$
+declare
+  programid integer default 0;
+  v_exist_subset integer[] default array[]::integer[];
+  v_no_exist varchar(1000) default '';
+  v_no_update varchar(1000) default '';
+  v_row_count integer DEFAULT 0;
+  out_msg varchar(1000) default '';
+begin
+	
+  -- Get the program_id for use in the rest of the script
+  select id into programid from public.app_iqprogramrd 
+  where is_active = true 
+  and program_name = programname;
+ 
+  -- Ensure the program exists
+  if programid is null then
+  	out_msg = 'The specified program is not an active program.';
+  	
+  else
+
+    -- Get users from input that aren't in the target table
+    select array_agg(user_id) into v_exist_subset from public.app_iqprogram
+    where program_id = programid 
+    and user_id = any(p_id);
+   
+    -- Compare p_id with v_exist_subset and output nonexistent users
+    select array_to_string(array_diff(p_id, v_exist_subset), ', ') into v_no_exist;
+  
+    -- Get users from input who are already not enrolled
+    select string_agg(user_id::text, ', ') into v_no_update from public.app_iqprogram
+    where program_id = programid 
+    and is_enrolled = false
+    and user_id = any(p_id);
+  	
+    -- Update app_iqprogram table, but only if is_enrolled is true (for timestamp validity)
+    UPDATE public.app_iqprogram
+    SET is_enrolled = false, enrolled_at = null
+    WHERE program_id = programid 
+    and is_enrolled = true
+    and user_id = any(p_id);
+   
+    -- Get number of included rows
+    get diagnostics v_row_count = row_count;
+   
+    -- Output completion details
+   
+    -- Determine plural
+    if v_row_count != 1 then
+    	out_msg = concat(v_row_count, ' users unenrolled.');
+    else
+    	out_msg = concat(v_row_count, ' user unenrolled.');
+    end if;
+   
+    if v_no_update != '' then
+    	-- Determine plural
+      if (select substring(v_no_update from ',')) is not null then
+      	out_msg = concat(out_msg, ' IDs ', v_no_update, ' were already unenrolled.');
+      else
+    		out_msg = concat(out_msg, ' ID ', v_no_update, ' was already unenrolled.');
+      end if;
+    end if;
+    
+    if v_no_exist != '' then
+    	-- Determine plural
+    	if (select substring(v_no_exist from ',')) is not null then
+    		out_msg = concat(out_msg, ' IDs ', v_no_exist, ' don''t exist for this program.');
+    	else
+    		out_msg = concat(out_msg, ' ID ', v_no_exist, ' doesn''t exist for this program.');
+    	end if;
+    end if;
+   
+  end if;
+  
+  return out_msg;
+END
+$$
+;

--- a/ref/sql/fn_app_user_archiveusers.sql
+++ b/ref/sql/fn_app_user_archiveusers.sql
@@ -1,0 +1,64 @@
+CREATE OR REPLACE FUNCTION public.app_user_archiveusers(VARIADIC p_id integer[])
+ RETURNS character varying
+ LANGUAGE plpgsql
+AS $$
+declare
+  v_exist_subset integer[] default array[]::integer[];
+  v_no_exist varchar(1000) default '';
+  v_no_update varchar(1000) default '';
+  v_row_count integer DEFAULT 0;
+  v_no_update_count integer DEFAULT 0;
+  out_msg varchar(1000) default '';
+begin
+
+  -- Get users from input that aren't in the target table
+  select array_agg(id) into v_exist_subset from public.app_user
+  where id = any(p_id);
+ 
+  -- Compare p_id with v_exist_subset and output nonexistent users
+  select array_to_string(array_diff(p_id, v_exist_subset), ', ') into v_no_exist;
+
+  -- Get users from input who are already archived
+  select string_agg(id::text, ', '), count(id) into v_no_update, v_no_update_count from public.app_user
+  where is_archived = true
+  and id = any(p_id);
+	
+  -- Update app_user table
+  UPDATE public.app_user
+  SET is_archived = true
+  WHERE id = any(p_id);
+    
+  -- Get number of included rows
+  get diagnostics v_row_count = row_count;
+ 
+  -- Output completion details
+ 
+  -- Determine plural
+  if v_row_count-v_no_update_count != 1 then
+  	out_msg = concat(v_row_count-v_no_update_count, ' users archived.');
+  else
+  	out_msg = concat(v_row_count-v_no_update_count, ' user archived.');
+  end if;
+ 
+  if v_no_update != '' then
+  	-- Determine plural
+    if (select substring(v_no_update from ',')) is not null then
+    	out_msg = concat(out_msg, ' IDs ', v_no_update, ' were already archived.');
+    else
+  		out_msg = concat(out_msg, ' ID ', v_no_update, ' was already archived.');
+    end if;
+  end if;
+  
+  if v_no_exist != '' then
+  	-- Determine plural
+  	if (select substring(v_no_exist from ',')) is not null then
+  		out_msg = concat(out_msg, ' IDs ', v_no_exist, ' don''t exist.');
+  	else
+  		out_msg = concat(out_msg, ' ID ', v_no_exist, ' doesn''t exist.');
+  	end if;
+  end if;
+  
+  return out_msg;
+END
+$$
+;

--- a/ref/sql/fn_app_user_unarchiveusers.sql
+++ b/ref/sql/fn_app_user_unarchiveusers.sql
@@ -1,0 +1,64 @@
+CREATE OR REPLACE FUNCTION public.app_user_unarchiveusers(VARIADIC p_id integer[])
+ RETURNS character varying
+ LANGUAGE plpgsql
+AS $$
+declare
+  v_exist_subset integer[] default array[]::integer[];
+  v_no_exist varchar(1000) default '';
+  v_no_update varchar(1000) default '';
+  v_row_count integer DEFAULT 0;
+  v_no_update_count integer DEFAULT 0;
+  out_msg varchar(1000) default '';
+begin
+ 
+  -- Get users from input that aren't in the target table
+  select array_agg(id) into v_exist_subset from public.app_user
+  where id = any(p_id);
+ 
+  -- Compare p_id with v_exist_subset and output nonexistent users
+  select array_to_string(array_diff(p_id, v_exist_subset), ', ') into v_no_exist;
+
+  -- Get users from input who are already not archived
+  select string_agg(id::text, ', '), count(id) into v_no_update, v_no_update_count from public.app_user
+  where is_archived = false
+  and id = any(p_id);
+	
+  -- Update app_user table
+  UPDATE public.app_user
+  SET is_archived = false
+  WHERE id = any(p_id);
+    
+  -- Get number of included rows
+  get diagnostics v_row_count = row_count;
+ 
+  -- Output completion details
+ 
+  -- Determine plural
+  if v_row_count-v_no_update_count != 1 then
+  	out_msg = concat(v_row_count-v_no_update_count, ' users unarchived.');
+  else
+  	out_msg = concat(v_row_count-v_no_update_count, ' user unarchived.');
+  end if;
+ 
+  if v_no_update != '' then
+  	-- Determine plural
+    if (select substring(v_no_update from ',')) is not null then
+    	out_msg = concat(out_msg, ' IDs ', v_no_update, ' were already unarchived.');
+    else
+  		out_msg = concat(out_msg, ' ID ', v_no_update, ' was already unarchived.');
+    end if;
+  end if;
+  
+  if v_no_exist != '' then
+  	-- Determine plural
+  	if (select substring(v_no_exist from ',')) is not null then
+  		out_msg = concat(out_msg, ' IDs ', v_no_exist, ' don''t exist.');
+  	else
+  		out_msg = concat(out_msg, ' ID ', v_no_exist, ' doesn''t exist.');
+  	end if;
+  end if;
+  
+  return out_msg;
+END
+$$
+;

--- a/ref/sql/fn_array_diff.sql
+++ b/ref/sql/fn_array_diff.sql
@@ -1,0 +1,6 @@
+create or replace function array_diff(test_array anyarray, compare_array anyarray)
+returns anyarray language sql immutable as $$
+    select coalesce(array_agg(elem), '{}')
+    from unnest(test_array) elem
+    where elem <> all(compare_array)
+$$;


### PR DESCRIPTION
Add script to create/update functions to perform user administration. The functions have already been created in `getyour_prod` and `getyour_dev`.

- Set `is_income_verified`
- Unset `is_income_verified`
- Set `is_enrolled` for a program
- Unset `is_enrolled` for a program - FOR REFERENCE ONLY (this is an unintended usage for this data)
- Archive users
- Unarchive users

Fixes #103 