### PR TITLE
Fix mapping for programs route in what_page_renewal

### DIFF
--- a/getyour/app/backend.py
+++ b/getyour/app/backend.py
@@ -671,7 +671,7 @@ def what_page_renewal(last_renewal_action):
         'address': 'app:address',
         'household': 'app:household',
         'household_members': 'app:household_members',
-        'eligibility_programs': 'app:eligibility_programs',
+        'eligibility_programs': 'app:programs',
         'files': 'app:files'
     }
 


### PR DESCRIPTION
This fixes a error related to how the what_page_renewal function returns an invalid route. It was initially setup to return `app:eligibility_programs`, but this wasn't a valid route. It's been changed to use the actual named route for programs: `app:programs`