### PR TITLE
Login and Valid Route Middlewares

### DIFF
--- a/getyour/app/backend.py
+++ b/getyour/app/backend.py
@@ -671,7 +671,7 @@ def what_page_renewal(last_renewal_action):
         'address': 'app:address',
         'household': 'app:household',
         'household_members': 'app:household_members',
-        'eligibility_programs': 'app:eligibility_programs',
+        'eligibility_programs': 'app:programs',
         'files': 'app:files'
     }
 

--- a/getyour/getyour/middleware.py
+++ b/getyour/getyour/middleware.py
@@ -1,6 +1,73 @@
 from django.shortcuts import redirect
+from django.urls import reverse, resolve, Resolver404
 from django.utils.deprecation import MiddlewareMixin
+from django.http import HttpResponseRedirect
 from app.backend import what_page_renewal
+
+
+class LoginRequiredMiddleware(MiddlewareMixin):
+    """
+    Middleware that checks if the user is logged in and redirects them to the correct page.
+    """
+
+    def process_request(self, request):
+        if not request.user.is_authenticated:
+            # If the route is in excluded_paths don't do anything
+            excluded_paths = [
+                reverse('app:login'),
+                reverse('app:index'),
+                reverse('app:get_ready'),
+                reverse('app:account'),
+                reverse('app:privacy_policy'),
+                reverse('app:password_reset'),
+                reverse('app:quick_available'),
+                reverse('app:quick_not_available'),
+                reverse('app:quick_coming_soon'),
+                reverse('app:quick_not_found'),
+                reverse('app:programs_info'),
+                reverse('app:privacy_policy'),
+                reverse('password_reset_done'),
+                reverse('password_reset_complete'),
+            ]
+
+            current_path = request.path_info
+            # Get the view instance that's handling the current request
+
+            if current_path in excluded_paths:
+                pass
+            elif 'reset' in current_path:
+                pass
+            else:
+                return HttpResponseRedirect(reverse("app:login"))
+
+
+class ValidRouteMiddleware(MiddlewareMixin):
+    """
+    Middleware that checks if the user is in a valid route and redirects them to the correct page.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return self.process_response(request, response)
+
+    def process_response(self, request, response):
+        if not self.is_valid_route(request):
+            # Redirect to the dashboard
+            return redirect(reverse("app:dashboard"))
+
+        return response
+
+    def is_valid_route(self, request):
+        try:
+            resolve(request.path)
+            return True
+        except Resolver404:
+            pass
+
+        return False
 
 
 class RenewalModeMiddleware(MiddlewareMixin):

--- a/getyour/getyour/settings/caution_local_proddb.py
+++ b/getyour/getyour/settings/caution_local_proddb.py
@@ -86,6 +86,8 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',  # add whitenoise
+    'getyour.middleware.LoginRequiredMiddleware',
+    'getyour.middleware.ValidRouteMiddleware',
     'getyour.middleware.RenewalModeMiddleware',
 ]
 

--- a/getyour/getyour/settings/common_settings.py
+++ b/getyour/getyour/settings/common_settings.py
@@ -45,6 +45,8 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',  # add whitenoise
+    'getyour.middleware.LoginRequiredMiddleware',
+    'getyour.middleware.ValidRouteMiddleware',
     'getyour.middleware.RenewalModeMiddleware',
 ]
 

--- a/getyour/getyour/settings/dev.py
+++ b/getyour/getyour/settings/dev.py
@@ -74,6 +74,8 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',  # add whitenoise
+    'getyour.middleware.LoginRequiredMiddleware',
+    'getyour.middleware.ValidRouteMiddleware',
     'getyour.middleware.RenewalModeMiddleware',
 ]
 

--- a/getyour/getyour/settings/local.py
+++ b/getyour/getyour/settings/local.py
@@ -85,6 +85,8 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',  # add whitenoise
+    'getyour.middleware.LoginRequiredMiddleware',
+    'getyour.middleware.ValidRouteMiddleware',
     'getyour.middleware.RenewalModeMiddleware',
 ]
 

--- a/getyour/getyour/settings/local_devdb.py
+++ b/getyour/getyour/settings/local_devdb.py
@@ -85,6 +85,8 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',  # add whitenoise
+    'getyour.middleware.LoginRequiredMiddleware',
+    'getyour.middleware.ValidRouteMiddleware',
     'getyour.middleware.RenewalModeMiddleware',
 ]
 

--- a/getyour/getyour/settings/local_stagedb.py
+++ b/getyour/getyour/settings/local_stagedb.py
@@ -85,6 +85,8 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',  # add whitenoise
+    'getyour.middleware.LoginRequiredMiddleware',
+    'getyour.middleware.ValidRouteMiddleware',
     'getyour.middleware.RenewalModeMiddleware',
 ]
 

--- a/getyour/getyour/settings/production.py
+++ b/getyour/getyour/settings/production.py
@@ -72,6 +72,8 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',  # add whitenoise
+    'getyour.middleware.LoginRequiredMiddleware',
+    'getyour.middleware.ValidRouteMiddleware',
     'getyour.middleware.RenewalModeMiddleware',
 ]
 


### PR DESCRIPTION
The `login_validroute_middleware` branch was created as a branch off the `what_page_renewal_fix` branch. Currently, there's an open Pull Request (PR #233) for the `what_page_renewal_fix` branch. It is advisable to review and approve that PR first, if the changes are deemed acceptable, before moving on to reviewing this PR.

This Pull Request introduces two new middlewares into Django's middleware pipeline:

1. `LoginRequiredMiddleware`: This middleware prevents users from accessing certain routes without being authenticated. The primary objective is to avoid users encountering server error pages when attempting to access unauthorized pages through bookmarks or saved links. However, some routes are exempted from this middleware, including landing, login, and password reset pages, among others. A comprehensive list of exempted routes can be found in the `excluded_paths` variable.

2. `ValidRouteMiddleware`: This middleware addresses cases where users might encounter a 404 error due to bookmarking an outdated URL, having outdated links in their browser history, or manually entering an invalid URL. The middleware redirects such users to their `dashboard`. Notably, checking for valid routes is not required for unauthenticated users due to the order of operations in Django's middleware pipeline. Unauthenticated users will be redirected to the login page if they access an invalid route.
