### PR TITLE
Converted timestamps to timezone-aware

### DIFF
--- a/getyour/Dockerfile
+++ b/getyour/Dockerfile
@@ -21,6 +21,7 @@ RUN pip install django-environ==0.10.0
 RUN pip install django-storages[azure]==1.12.3
 RUN pip install django-phonenumber-field[phonenumbers]==7.1.0
 RUN pip install gunicorn==20.1.0
+RUN pip install pendulum==2.1.2
 RUN pip install psycopg2-binary==2.9.6
 RUN pip install python-magic==0.4.27
 RUN pip install sendgrid==6.6.0

--- a/getyour/getyour/settings/common_settings.py
+++ b/getyour/getyour/settings/common_settings.py
@@ -18,7 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 import os
 from pathlib import Path
-from datetime import datetime
+import pendulum
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -118,8 +118,7 @@ AZURE_LOCATION = ""  # Subdirectory-like prefix to the blob name
 DEFAULT_FILE_STORAGE = 'getyour.settings.custom_azure.AzureMediaStorage'
 
 # Logging
-str = str((datetime.now().time()))
-logFileName = str.replace(":", "_")
+logFileName = pendulum.now().format("HH_mm_ss.SSSSSS")
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,

--- a/getyour/getyour/settings/common_settings.py
+++ b/getyour/getyour/settings/common_settings.py
@@ -96,13 +96,14 @@ AUTH_PASSWORD_VALIDATORS = [
 # https://docs.djangoproject.com/en/3.1/topics/i18n/
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'EST'
+# USE_TZ means that all timestamps are timezone-aware, and since the backend db
+# is also timezone-aware, TIME_ZONE doesn't really matter for current use cases
+USE_TZ = True
+TIME_ZONE = 'America/Denver'
 
 USE_I18N = True
 
 USE_L10N = True
-
-USE_TZ = True
 
 # For phone number default region setting:
 PHONENUMBER_DEFAULT_REGION = 'US'

--- a/getyour/requirements.txt
+++ b/getyour/requirements.txt
@@ -3,6 +3,7 @@ django-environ==0.10.0
 django-storages[azure]==1.12.3
 django-phonenumber-field[phonenumbers]==7.1.0
 gunicorn==20.1.0
+pendulum==2.1.2
 psycopg2-binary==2.9.6
 python-magic==0.4.27
 sendgrid==6.6.0


### PR DESCRIPTION
- Converted all timestamps not defined by Django to use [`pendulum`](https://pendulum.eustace.io/docs)
- Updated Django's `TIME_ZONE` var to MST, although it doesn't currently affect the app (because `USE_TZ==True` and all storage and timestamps are timezone-aware)

- Fixes #255 
- Fixes #229 
- Fixes #261 by using UTC timestamps for all filenames