### PR TITLE
Updated secrets filenames to proper naming convention

### DIFF
--- a/getyour/getyour/settings/caution_local_proddb.py
+++ b/getyour/getyour/settings/caution_local_proddb.py
@@ -25,7 +25,7 @@ from getyour.settings.common_settings import *
 
 # SECURITY WARNING: keep the secret key used in production secret!
 # TOML-based secrets module
-with open('secrets_prod.toml', 'r', encoding='utf-8') as f:
+with open('secrets.prod.toml', 'r', encoding='utf-8') as f:
     secrets_dict = loads(f.read())
 
 def get_secret(var_name, read_dict=secrets_dict):

--- a/getyour/getyour/settings/local.py
+++ b/getyour/getyour/settings/local.py
@@ -25,7 +25,7 @@ from getyour.settings.common_settings import *
 
 # SECURITY WARNING: keep the secret key used in production secret!
 # TOML-based secrets module
-with open('secrets_dev.toml', 'r', encoding='utf-8') as f:
+with open('secrets.dev.toml', 'r', encoding='utf-8') as f:
     secrets_dict = loads(f.read())
 
 def get_secret(var_name, read_dict=secrets_dict):

--- a/getyour/getyour/settings/local_devdb.py
+++ b/getyour/getyour/settings/local_devdb.py
@@ -25,7 +25,7 @@ from getyour.settings.common_settings import *
 
 # SECURITY WARNING: keep the secret key used in production secret!
 # TOML-based secrets module
-with open('secrets_dev.toml', 'r', encoding='utf-8') as f:
+with open('secrets.dev.toml', 'r', encoding='utf-8') as f:
     secrets_dict = loads(f.read())
 
 def get_secret(var_name, read_dict=secrets_dict):

--- a/getyour/getyour/settings/local_stagedb.py
+++ b/getyour/getyour/settings/local_stagedb.py
@@ -25,7 +25,7 @@ from getyour.settings.common_settings import *
 
 # SECURITY WARNING: keep the secret key used in production secret!
 # TOML-based secrets module
-with open('secrets_prod.toml', 'r', encoding='utf-8') as f:
+with open('secrets.prod.toml', 'r', encoding='utf-8') as f:
     secrets_dict = loads(f.read())
 
 def get_secret(var_name, read_dict=secrets_dict):


### PR DESCRIPTION
This changes the 'secrets' filename references to match the naming convention from the templates in `ref/env_vars/`.