### PR TITLE
Added settings for more-secure session management

### DIFF
--- a/getyour/getyour/settings/common_settings.py
+++ b/getyour/getyour/settings/common_settings.py
@@ -63,6 +63,12 @@ MIDDLEWARE = [
     'getyour.middleware.RenewalModeMiddleware',
 ]
 
+# Session management
+# Log out on browser close
+SESSION_EXPIRE_AT_BROWSER_CLOSE = True
+# Expire the session cookie (force re-login) at 6 hours (in seconds)
+SESSION_COOKIE_AGE = 6*60*60
+
 ROOT_URLCONF = 'getyour.urls'
 AUTH_USER_MODEL = "app.User"
 


### PR DESCRIPTION
The default Django session is alive until the user selects 'log out' (when `logout(request)` is called) or 2 weeks have elapsed, regardless of the state of their browser window. This updates the session to

- expire after 6 hours OR
- expire when the user closes their browser (important for use on public computers)

In the meantime, I have a scheduled task running daily at midnight to kill all user sessions.