### PR TITLE
Modifications to LoginRequired and ValidRoute middleware

### DIFF
--- a/getyour/app/templates/404.html
+++ b/getyour/app/templates/404.html
@@ -1,0 +1,34 @@
+<!--
+Get-Your is a platform for application and administration of income-
+qualified programs, used primarily by the City of Fort Collins.
+Copyright (C) 2023
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+{% extends "bases/availability_base.html" %}
+{% load static %}
+
+{% block navigation %}
+{% url 'app:index' as back_link %}
+{% include "partials/navigation.html" with display_back_link=True display_save_link=False back_link=back_link %}
+{% endblock %}
+
+{% block content %}
+<h1 style="overflow: hidden; padding: auto; font-weight: bold;">
+    Oops, the page you're looking for doesn't exist or can't be found (Error 404).
+</h1>
+<p style="margin-top: 2vh;">
+    Please try another link or <a href="{% url 'app:dashboard' %}">go to your dashboard.</a>
+</p>
+{% endblock %}

--- a/getyour/getyour/middleware.py
+++ b/getyour/getyour/middleware.py
@@ -1,12 +1,14 @@
 from django.shortcuts import redirect
 from django.urls import reverse, resolve
-from django.http import HttpResponseRedirect
 from app.backend import what_page_renewal
 
 
 class LoginRequiredMiddleware:
     """
-    Middleware that checks if the user is logged in and redirects them to the correct page.
+    Middleware that checks if the user is logged in and redirects them to the
+    dashboard. The dashboard is always the target because there's no way to
+    ensure all parameters for the various states are set properly.
+
     """
 
     def __init__(self, get_response):
@@ -25,27 +27,24 @@ class LoginRequiredMiddleware:
                 reverse('app:index'),
                 reverse('app:get_ready'),
                 reverse('app:account'),
-                reverse('app:privacy_policy'),
-                reverse('app:password_reset'),
                 reverse('app:quick_available'),
                 reverse('app:quick_not_available'),
                 reverse('app:quick_coming_soon'),
                 reverse('app:quick_not_found'),
                 reverse('app:programs_info'),
                 reverse('app:privacy_policy'),
+                reverse('app:password_reset'),
                 reverse('password_reset_done'),
                 reverse('password_reset_complete'),
             ]
 
-            current_path = request.path_info
             # Get the view instance that's handling the current request
-
-            if current_path in excluded_paths:
-                pass
-            elif 'reset' in current_path:
-                pass
-            else:
-                return HttpResponseRedirect(reverse("app:login"))
+            current_path = request.path_info
+            
+            # Redirect to login if the current path isn't excluded or includes
+            # 'reset'. The login workflow will take over after successful auth
+            if not (current_path in excluded_paths or 'reset' in current_path):
+                return redirect("app:login")
 
         # Default to calling the specified view
         response = self.get_response(request)
@@ -54,7 +53,7 @@ class LoginRequiredMiddleware:
         # the view is called.
 
         return response
-
+    
 
 class ValidRouteMiddleware:
     """

--- a/getyour/getyour/settings/common_settings.py
+++ b/getyour/getyour/settings/common_settings.py
@@ -58,8 +58,8 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
-    'getyour.middleware.LoginRequiredMiddleware',
     'getyour.middleware.ValidRouteMiddleware',
+    'getyour.middleware.LoginRequiredMiddleware',
     'getyour.middleware.RenewalModeMiddleware',
 ]
 


### PR DESCRIPTION
`ValidRouteMiddleware`:

Modified to raise a 404 error instead of automatically redirecting users, for transparency into broken links. To maintain the convenience to the user of the previous version, though, a custom branded `404.html` template was added that has a 'proceed to dashboard' link and the 'back' link leads to the home page. Finally, `ValidRouteMiddleware` was moved above `LoginRequiredMiddleware` so that the 404 page is thrown prior to a user needing to log in (and along with this, the 'proceed to dashboard' link on the 404 page will prompt the auth workflow since the user may not be logged in).

`LoginRequiredMiddleware`:

Modified to use modern Django middleware methods and compressed the case expression for readability.

`RenewalModeMiddleware`:

Modified to use modern Django middleware methods.