### PR TITLE
4.0.3 RC: Bug fix in Q_CLUSTER settings

### DIFF
--- a/getyour/app/tasks.py
+++ b/getyour/app/tasks.py
@@ -28,7 +28,7 @@ def run_renewal_task():
     for user in User.objects.filter(
         is_archived=False,
         last_completed_at__isnull=False,
-    ):
+    ).order_by('id'):
         async_task(send_renewal_email, user)
 
 

--- a/getyour/getyour/settings/dev.py
+++ b/getyour/getyour/settings/dev.py
@@ -85,11 +85,18 @@ DATABASES = {
 if DEBUG_LOGGING:
     LOGGING['loggers']['app']['level'] = 'DEBUG'
 
-
 Q_CLUSTER = {
     'name': 'DjangORM',
     'workers': 4,
+    # Each worker is constrained to the timeout period
     'timeout': 30,
+    # Each worker and the scheduled task itself is constrained to the retry
+    # period. At least some scheduled tasks in Get-Your are expected to be long-
+    # running because they loop through each user; set this accordingly
+    'retry': 21500,     # just under 6 hours
+    # The max_attempts parameter is actually a limit for number of *retries*.
+    # Appears to only accept positive integer or zero; zero indicates 'infinite'
+    'max_attempts': 1,
     'bulk': 10,
     'orm': 'default',
     'catch_up': False,

--- a/getyour/getyour/settings/local.py
+++ b/getyour/getyour/settings/local.py
@@ -85,7 +85,15 @@ DEBUG_LOGGING = True
 Q_CLUSTER = {
     'name': 'DjangORM',
     'workers': 4,
+    # Each worker is constrained to the timeout period
     'timeout': 30,
+    # Each worker and the scheduled task itself is constrained to the retry
+    # period. At least some scheduled tasks in Get-Your are expected to be long-
+    # running because they loop through each user; set this accordingly
+    'retry': 21500,     # just under 6 hours
+    # The max_attempts parameter is actually a limit for number of *retries*.
+    # Appears to only accept positive integer or zero; zero indicates 'infinite'
+    'max_attempts': 1,
     'bulk': 10,
     'orm': 'default',
     'catch_up': False,

--- a/getyour/getyour/settings/local_devdb.py
+++ b/getyour/getyour/settings/local_devdb.py
@@ -90,7 +90,15 @@ DEBUG_LOGGING = True
 Q_CLUSTER = {
     'name': 'DjangORM',
     'workers': 4,
+    # Each worker is constrained to the timeout period
     'timeout': 30,
+    # Each worker and the scheduled task itself is constrained to the retry
+    # period. At least some scheduled tasks in Get-Your are expected to be long-
+    # running because they loop through each user; set this accordingly
+    'retry': 21500,     # just under 6 hours
+    # The max_attempts parameter is actually a limit for number of *retries*.
+    # Appears to only accept positive integer or zero; zero indicates 'infinite'
+    'max_attempts': 1,
     'bulk': 10,
     'orm': 'default',
     'catch_up': False,

--- a/getyour/getyour/settings/production.py
+++ b/getyour/getyour/settings/production.py
@@ -88,7 +88,15 @@ if DEBUG_LOGGING:
 Q_CLUSTER = {
     'name': 'DjangORM',
     'workers': 4,
+    # Each worker is constrained to the timeout period
     'timeout': 30,
+    # Each worker and the scheduled task itself is constrained to the retry
+    # period. At least some scheduled tasks in Get-Your are expected to be long-
+    # running because they loop through each user; set this accordingly
+    'retry': 21500,     # just under 6 hours
+    # The max_attempts parameter is actually a limit for number of *retries*.
+    # Appears to only accept positive integer or zero; zero indicates 'infinite'
+    'max_attempts': 1,
     'bulk': 10,
     'orm': 'default',
     'catch_up': False,

--- a/getyour/getyour/settings/stage.py
+++ b/getyour/getyour/settings/stage.py
@@ -88,7 +88,15 @@ if DEBUG_LOGGING:
 Q_CLUSTER = {
     'name': 'DjangORM',
     'workers': 4,
+    # Each worker is constrained to the timeout period
     'timeout': 30,
+    # Each worker and the scheduled task itself is constrained to the retry
+    # period. At least some scheduled tasks in Get-Your are expected to be long-
+    # running because they loop through each user; set this accordingly
+    'retry': 21500,     # just under 6 hours
+    # The max_attempts parameter is actually a limit for number of *retries*.
+    # Appears to only accept positive integer or zero; zero indicates 'infinite'
+    'max_attempts': 1,
     'bulk': 10,
     'orm': 'default',
     'catch_up': False,


### PR DESCRIPTION
- Sets `retry` and `max_attempts` in `Q_CLUSTER`, with a better understand of each parameter's effect on the workers and tasks
    - The defaults are '60 seconds' and 'infinite', respectively
- Orders the users in the Run Renewal Task loop for easier tracing/debugging

For scheduled tasks, [v4.0.2](https://github.com/Get-Your/Get-Your/releases/tag/v4.0.2) fixed the `timeout` issue by distributing tasks to the available workers, but `retry` (which was reverted to the default 60 seconds) then created a problem. While `timeout` constrains each worker, `retry` constrains each worker *and* the scheduled task; when the Run Renewal Task (that loops through each active user - a rather-long-running task) ran, it would retry/restart after 60 seconds, which assigns the workers values at the beginning of the loop again and bogs everything down such that it ends up never getting past a certain loop value.